### PR TITLE
Remoção do campo CNS como obrigatório / Inserção do maxlength no input da pág admin

### DIFF
--- a/app/forms/inputs.py
+++ b/app/forms/inputs.py
@@ -117,7 +117,7 @@ cns = Input(
     label='CNS',
     placeholder='999.999.999.999.999',
     mask='999.999.999.999.999',
-    required=True
+    required=False
 )
 
 telefone = Input(

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -41,8 +41,8 @@
                                     <input type="hidden" name="user_id" value={{user.id}}>
                                     <td><input class="form-control" type="text" name="nome" value={{user.nome}}>
                                     </td>
-                                    <td><input class="form-control" type="text" name="crm" value={{user.crm}}></td>
-                                    <td><input class="form-control" type="text" name="cpf" value={{user.cpf}}></td>
+                                    <td><input class="form-control" type="text" name="crm" value={{user.crm}} maxlength="20"></td>
+                                    <td><input class="form-control" type="text" name="cpf" value={{user.cpf}} maxlength="11"></td>
                                     <td>
                                         {% if user.is_supervisor %}
                                             <input class="form-control" type="checkbox" name="is_supervisor"
@@ -95,9 +95,9 @@
                                     <input type="hidden" name="paciente_id" value={{paciente.id}}>
                                     <td><input class="form-control" type="text" name="nome" value={{paciente.nome}}>
                                     </td>
-                                    <td><input class="form-control" type="text" name="cpf" value={{paciente.cpf}}></td>
-                                    <td><input class="form-control" type="text" name="cns" value={{paciente.cns}}></td>
-                                    <td><input class="form-control" type="text" name="telefone" value={{paciente.telefone}}></td>
+                                    <td><input class="form-control" type="text" name="cpf" value={{paciente.cpf}} maxlength="11"></td>
+                                    <td><input class="form-control" type="text" name="cns" value={{paciente.cns}} maxlength="15"></td>
+                                    <td><input class="form-control" type="text" name="telefone" value={{paciente.telefone}} maxlength="11"></td>
                                     <td><select class="form-control" name="id_genero">
                                         {% for genero in generos %}
                                             {% if genero.id == paciente.id_genero %}    

--- a/app/templates/agendamento.html
+++ b/app/templates/agendamento.html
@@ -1,10 +1,26 @@
 {% if pdf %}
 <style>
-    table, th, td {
-      border: 1px solid black;
+
+    table {
+        font-family: arial, sans-serif;
+        border-collapse: collapse;
+        width: 100%;
     }
+
+    thead{
+        background-color: #2f4050;
+        color: white;
+    }
+
+    thead,td{
+        border: 1px solid #dddddd;
+        text-align: left;
+        padding: 8px;
+    }
+
 </style>
 {%endif%}
+
 <div class="tab-content">
     <div id="tab-1" class="tab-pane active">
         <div class="full-height-scroll">


### PR DESCRIPTION
O campo CNS estava como obrigatório, essa obrigatoriedade foi retirada.

Adicionei o campo maxlength nos inputs (CPF,CRM,CNS e telefone) da página admin, para evitar que o usuário digite mais número que o necessário e cause um erro na hora de salvar. 